### PR TITLE
Use sequential fmt placeholders for hyperref snippet

### DIFF
--- a/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
+++ b/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
@@ -123,7 +123,7 @@ function M.retrieve(is_math)
     snips,
     s(
       { trig = "hpr", name = "\\hyperref[]{}", snippetType = "snippet" },
-      fmt("\\hyperref[{1}]{{{2}}} {0}", { i(1), i(2), i(0) }),
+      fmt("\\hyperref[{}]{{{}}} {}", { i(1), i(2), i(0) }),
       { condition = not_math }
     )
   )


### PR DESCRIPTION
## Summary
- rework the `\hyperref` snippet to use sequential fmt placeholders so the trailing insert node is always defined

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3e54594948324a4ea6fa354568026