### PR TITLE
Fix remark and definition snippet placeholders

### DIFF
--- a/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
+++ b/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
@@ -137,7 +137,7 @@ function M.retrieve(is_math)
     snips,
     s(
       { trig = "rmk", name = "remark env", snippetType = "snippet" },
-      fmt("\\begin{remark}\n\t{}\n\\end{remark}", { i(0) }),
+      fmt("\\begin{{remark}}\n\t{}\n\\end{{remark}}", { i(0) }),
       { condition = not_math }
     )
   )
@@ -146,7 +146,7 @@ function M.retrieve(is_math)
     snips,
     s(
       { trig = "dfn", name = "definition env", snippetType = "snippet" },
-      fmt("\\begin{definition}\n\t{}\n\\end{definition}", { i(0) }),
+      fmt("\\begin{{definition}}\n\t{}\n\\end{{definition}}", { i(0) }),
       { condition = not_math }
     )
   )


### PR DESCRIPTION
## Summary
- escape the LaTeX environment braces in the remark and definition snippets
- prevent LuaSnip's fmt helper from treating the environment names as missing keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e71b916c8324998174bd1b132ed3