### PR TITLE
Fix boundary helper for regex triggers

### DIFF
--- a/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
+++ b/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
@@ -31,11 +31,10 @@ function M.retrieve(is_math)
   end
 
   -- Boundary: “not preceded by a backslash or letter”
-  local function clean_boundary(_, snip)
-    local lnum, col = unpack(vim.api.nvim_win_get_cursor(0))
-    local line = vim.api.nvim_buf_get_lines(0, lnum - 1, lnum, false)[1] or ""
-    local pos = col - #snip.trigger
-    local prev = (pos > 0) and line:sub(pos, pos) or ""
+  local function clean_boundary(line_to_cursor, matched_trigger)
+    local trig = matched_trigger or ""
+    local pos = #line_to_cursor - #trig
+    local prev = (pos > 0) and line_to_cursor:sub(pos, pos) or ""
     return not prev:match("[%a\\]")
   end
 


### PR DESCRIPTION
## Summary
- update the clean_boundary helper to rely on the matched trigger text instead of snippet metadata
- prevent errors when autosnippets with regex triggers invoke the boundary guard

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3e812c4388324a5d2fbd4fe3950a8