### PR TITLE
Convert braces snippet to manual trigger

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -38,7 +38,7 @@ Math delimiters and wrappers
 | fm | \( … \) | Both | Yes | Overlay |
 | lrd | \left( … \right) | Math | Yes | Overlay |
 | lrq | \left[ … \right] | Math | Yes | Overlay |
-| {} | \{ … \} | Math | Yes | Overlay; wordTrig=false |
+| {} | \{ … \} | Math | No | Overlay; wordTrig=false |
 | <> | \langle … \rangle | Math | Yes | Overlay |
 | lr, | \left\langle … \right\rangle | Math | Yes | Overlay |
 | lr | \left( … \right) | Math | No | New pack |

--- a/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
+++ b/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
@@ -253,7 +253,7 @@ function M.retrieve(is_math)
   table.insert(
     snips,
     s(
-      { trig = "{}", name = "{}", wordTrig = false, snippetType = "autosnippet" },
+      { trig = "{}", name = "{}", wordTrig = false },
       fmt("\\{{ {} \\}} {}", { i(1), i(0) }),
       { condition = in_math }
     )


### PR DESCRIPTION
## Summary
- switch the `{}` math snippet from an autosnippet to a regular snippet so it waits for Tab
- update the documentation table to reflect the manual trigger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1848f6f4832482e4e1ce270b52e8