### PR TITLE
Require double-letter triggers for mathbb snippets

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -59,7 +59,7 @@ Math delimiters and wrappers
 | rm | \mathrm{…} | Math | No | Overlay |
 | Acal/acal | \mathcal{A} | Math | No | Overlay (pattern) |
 | Ascr/ascr | \mathscr{A} | Math | No | Overlay (pattern) |
-| \a (any letter) | \mathbb{A} | Math | Yes | Both sets provide; same result |
+| \ll (any double letter) | \mathbb{l} | Math | Yes | Both sets provide; same result |
 
 Math environments
 | Trigger | Expands to | Mode | Auto? | Notes |
@@ -219,7 +219,7 @@ Postfix wrappers (attach a short marker after a token)
   - tokenbf → \mathbf{token}
   - tokenbm → \bm{token} (needs bm)
   - token,. or token., → \vec{token}
-  - \a (any letter) → \mathbb{A}
+  - \ll (any double letter) → \mathbb{l}
   - \bXYn → X_{Y+n} (single letters, n digit)
 - New pack (no-backslash word wrappers):
   - xbar → \overline{x}

--- a/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
+++ b/lua/luasnip-latex-snippets/luasnip-latex-snippets.mine.lua
@@ -664,9 +664,9 @@ function M.retrieve(is_math)
   table.insert(
     snips,
     s(
-      { trig = "\\([A-Za-z])", name = "\\mathbb{A}", regTrig = true, wordTrig = false },
+      { trig = "\\([A-Za-z])\\1", name = "\\mathbb{A}", regTrig = true, wordTrig = false },
       f(function(_, snip)
-        return "\\mathbb{" .. snip.captures[1]:upper() .. "} "
+        return "\\mathbb{" .. snip.captures[1] .. "} "
       end),
       { condition = in_math }
     )
@@ -874,9 +874,9 @@ function M.retrieve(is_math)
   table.insert(
     snips,
     s(
-      { trig = [[\\\([A-Za-z]\)]], regTrig = true, trigEngine = "vim", name = "\\mathbb{A}", snippetType = "autosnippet" },
+      { trig = [[\\\([A-Za-z]\)\1]], regTrig = true, trigEngine = "vim", name = "\\mathbb{A}", snippetType = "autosnippet" },
       f(function(_, snip)
-        return "\\mathbb{" .. snip.captures[1]:upper() .. "} "
+        return "\\mathbb{" .. snip.captures[1] .. "} "
       end),
       { condition = in_math }
     )


### PR DESCRIPTION
## Summary
- require mathbb snippets to be triggered by a double-letter pattern to reduce accidental expansions
- preserve the original letter casing when producing the mathbb wrapper
- document the new double-letter mathbb trigger in the docs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9f064b0fc8324aa74eb106edd987b